### PR TITLE
Remove web protocols on telegram webhook helper setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The starter comes with some useful helpers for convenience that can be found in 
 
 ```
 .
+├── .env - Project environment variable.
 ├── bootstrap - Bot bootstrapping files.
 ├── bot - Your bot main files.
 │   ├── Commands - Bot commands.
@@ -40,12 +41,22 @@ The starter comes with some useful helpers for convenience that can be found in 
 │   ├── Http - Bot controllers.
 │   └── Listeners - Event Listeners.
 ├── config - Config files.
+|   └── telegram.php - Your main SDK configuration.
 └── public - Public facing files.
+    └── index.php - Project index file.
+    └── pooling.php - Long-pooling update handler.
+    └── webhook.php - Webhook update handler.
 ```
 
 ## Webhook Setup
 
 > **IMPORTANT:** Telegram requires your domain to have an SSL certificate (https) to setup a webhook.
+
+Open `.env` and fill your webhook URL with :
+
+```
+TELEGRAM_WEBHOOK_DOMAIN=<https://yourdomain.com>
+```
 
 The standalone starter comes with a CLI helper to setup webhook for your bot. Simply fire the below command.
 
@@ -56,7 +67,7 @@ php telegram webhook:setup <botname>
 This will setup a webhook with a URL example:
 
 ```
-https://domain.com/webhook.php?token=YourBotToken&bot=YourBotName
+<https://yourdomain.com>/webhook.php?token=YourBotToken&bot=YourBotName
 ```
 
 The webhook file will verify any inbound requests to make sure its a valid request from Telegram.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ The starter comes with some useful helpers for convenience that can be found in 
 
 > **IMPORTANT:** Telegram requires your domain to have an SSL certificate (https) to setup a webhook.
 
-Open `.env` and fill your webhook URL with :
+Open `.env` and fill your domain:
 
 ```
-TELEGRAM_WEBHOOK_DOMAIN=<https://yourdomain.com>
+TELEGRAM_WEBHOOK_DOMAIN=<www.yourdomain.com>
 ```
 
 The standalone starter comes with a CLI helper to setup webhook for your bot. Simply fire the below command.
@@ -64,10 +64,10 @@ The standalone starter comes with a CLI helper to setup webhook for your bot. Si
 php telegram webhook:setup <botname>
 ```
 
-This will setup a webhook with a URL example:
+This will setup your bot's webhook to this URL:
 
 ```
-<https://yourdomain.com>/webhook.php?token=YourBotToken&bot=YourBotName
+<https://www.yourdomain.com>/webhook.php?token=YourBotToken&bot=YourBotName
 ```
 
 The webhook file will verify any inbound requests to make sure its a valid request from Telegram.

--- a/bot/Console/Webhook.php
+++ b/bot/Console/Webhook.php
@@ -55,6 +55,6 @@ class Webhook
             'bot'   => $this->bot->config('bot'),
         ]);
 
-        return sprintf("https://%s/webhook.php?%s", $domain, $params);
+        return sprintf("%s/webhook.php?%s", $domain, $params);
     }
 }

--- a/bot/Console/Webhook.php
+++ b/bot/Console/Webhook.php
@@ -55,6 +55,8 @@ class Webhook
             'bot'   => $this->bot->config('bot'),
         ]);
 
-        return sprintf("%s/webhook.php?%s", $domain, $params);
+        $domain = parse_url($domain, PHP_URL_HOST) ?? $domain;
+
+        return sprintf("https://%s/webhook.php?%s", $domain, $params);
     }
 }


### PR DESCRIPTION
I removed `https://` web protocol on create webhook CLI helper so domain URL value set up in `.env` file matches with value that will be set up at Telegram server. It's also to avoid error if user unconsciously put any HTTP protocols since the SDK already have validation for `http://` protocol.

Also added more guide for .env file on Webhook setup.
